### PR TITLE
[SIGGI-2739] Reworked login header, integrated realm-name in orbidder logo

### DIFF
--- a/src/login/Template.tsx
+++ b/src/login/Template.tsx
@@ -6,6 +6,7 @@ import { useInsertLinkTags } from "keycloakify/tools/useInsertLinkTags";
 import { useSetClassName } from "keycloakify/tools/useSetClassName";
 import type { I18n } from "./i18n";
 import type { KcContext } from "./KcContext";
+import "./template.css";
 import {
 	Alert,
 	Button,
@@ -116,10 +117,14 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
 	return (
 		<ThemeProvider theme={theme}>
 			<Container maxWidth="xl" sx={{ textAlign: "center", p: 2 }}>
-				<img src={`${import.meta.env.BASE_URL}img/orbidder-skylab.png`} />
-				<Typography variant="h4" color="primary">
-					{msg("loginTitleHtml", realm.displayNameHtml)}
-				</Typography>
+				<div className="logo-with-text">
+					<img src={`${import.meta.env.BASE_URL}img/orbidder-skylab.png`} className={"logo"} />
+					<div className='text-on-logo'>
+						<Typography variant="h4" color="primary">
+							for {msg("loginTitleHtml", realm.displayNameHtml)}
+						</Typography>
+					</div>
+				</div>
 			</Container>
 			<Container maxWidth="sm" component={Paper} sx={{ p: 2, mb: 1 }}>
 				<Grid container spacing={2} direction="column">

--- a/src/login/Template.tsx
+++ b/src/login/Template.tsx
@@ -120,7 +120,7 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
 				<div className="logo-with-text">
 					<img src={`${import.meta.env.BASE_URL}img/orbidder-skylab.png`} className={"logo"} />
 					<div className='text-on-logo'>
-						<Typography variant="h4" color="primary">
+						<Typography variant="h5" color="primary">
 							for {msg("loginTitleHtml", realm.displayNameHtml)}
 						</Typography>
 					</div>

--- a/src/login/template.css
+++ b/src/login/template.css
@@ -1,0 +1,15 @@
+.logo-with-text {
+    position: relative;
+    text-align: center;
+}
+
+.text-on-logo {
+    position: absolute;
+    right: 45%;
+    left: 30%;
+    bottom: 0;
+}
+
+.logo {
+    width: 60%;
+}

--- a/src/login/template.css
+++ b/src/login/template.css
@@ -5,11 +5,10 @@
 
 .text-on-logo {
     position: absolute;
-    right: 45%;
-    left: 30%;
-    bottom: 0;
+    left: 42%;
+    top: 75%;
 }
 
 .logo {
-    width: 60%;
+    width: 30%;
 }


### PR DESCRIPTION
In diesem Pull-Request wurden die Einstellungen vom Orbidder-Logo zum _css_ extragiert und das Logo wurde verkleinert.
Außerdem hatte ich eine Idee, nach meinem ziemlich eingeschränkten Design-Gefühl und abwesende UI-Erfahrung, der Name des Vermarkters(bzw. Account/Realm-Name) in das Orbidder-Logo zu integrieren.
Ich glaube, das sollte für die Skylab-Users etwas einladend wirken, etwa dabei zu sein  :)
![image](https://github.com/user-attachments/assets/cef6f50c-bbb6-416d-ba0c-cc26d9cd28d7)
 