### PR TITLE
[SIGGI-2987] Overwrite login verify email texts

### DIFF
--- a/src/login/i18n.ts
+++ b/src/login/i18n.ts
@@ -16,7 +16,8 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             footer_copyright: "Copyright ©",
             footer_imprint: "Impressum",
             footer_privacy: "Datenschutz",
-            for: "für"
+            for: "für",
+            emailVerifyInstruction2: "Sie haben keinen Verifizierungscode in Ihrer E-Mail erhalten?"
         },
         en: {
             // Needs to be redeclared, otherwhise TypeScript keeps complaining,

--- a/src/login/pages/LoginVerifyEmail.stories.tsx
+++ b/src/login/pages/LoginVerifyEmail.stories.tsx
@@ -27,3 +27,14 @@ export const Default: Story = {
         />
     )
 };
+export const German: Story = {
+    render: () => (
+        <KcPageStory
+            kcContext={{
+                locale: {
+                    currentLanguageTag: "de"
+                }
+            }}
+        />
+    )
+};


### PR DESCRIPTION
Obwohl der Gram-Fehler schon gefixt ist, s. [hier](https://github.com/keycloak/keycloak/blob/8b35fa58de6c4297391da04e9f1bec21260ec356/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties#L145) im Github Repo
und wir bauen bei uns damit Keycloak, bekommen wir immer noch die alte Ausgabe:
![image](https://github.com/user-attachments/assets/ae2cbe33-f5cd-40da-b3eb-f43757f8901f)
Deswegen ist hier der Workaround, die Meldung bei uns zu überschreiben. 
Dankeschön @arneschulz1984  für deine Unterstützung bei dem Thema!