### PR TITLE
Added overwrite email verify instruction for en because dependency

### DIFF
--- a/src/login/i18n.ts
+++ b/src/login/i18n.ts
@@ -28,7 +28,8 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             footer_copyright: "Copyright ©",
             footer_imprint: "Imprint",
             footer_privacy: "Privacy policy",
-            for: "for"
+            for: "for",
+            emailVerifyInstruction2: "Haven''t received a verification code in your email?"
         }
     })
     .build();


### PR DESCRIPTION
Wenn man Translation in Starter in einer Sprache überschreibt, braucht man es auch default(en) tun, sonst gibt es Compile-Errors